### PR TITLE
add support for GetFieldSlotIndex

### DIFF
--- a/processor/json-ld/processor_test.go
+++ b/processor/json-ld/processor_test.go
@@ -207,3 +207,32 @@ func TestParserWithSlotsTypes(t *testing.T) {
 	assert.Empty(t, parsedData.ValueB)
 
 }
+
+func TestGetFieldIndexWithSlotsTypes(t *testing.T) {
+
+	url = "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v2.json-ld"
+
+	loader := loaders.HTTP{}
+	validator := json.Validator{}
+	parser := jsonld.Parser{ClaimType: "KYCAgeCredential", ParsingStrategy: processor.OneFieldPerSlotStrategy}
+
+	jsonLdProcessor := New(processor.WithValidator(validator), processor.WithParser(parser), processor.WithSchemaLoader(loader))
+	schema, ext, err := jsonLdProcessor.Load(url)
+
+	assert.Nil(t, err)
+	assert.Equal(t, ext, "json-ld")
+	assert.NotEmpty(t, schema)
+
+	data := make(map[string]interface{})
+
+	data["birthday"] = 828522341
+	data["documentType"] = 1
+
+	slot2, err := jsonLdProcessor.GetFieldSlotIndex("birthday", schema)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, slot2)
+	slot3, err := jsonLdProcessor.GetFieldSlotIndex("documentType", schema)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, slot3)
+
+}

--- a/processor/json/processor_test.go
+++ b/processor/json/processor_test.go
@@ -139,3 +139,20 @@ func TestParser(t *testing.T) {
 	assert.Empty(t, parsedData.ValueB)
 
 }
+func TestGetFieldIndexWithSlotsTypes(t *testing.T) {
+
+	loader := loaders.HTTP{}
+	validator := json.Validator{}
+	parser := json.Parser{ParsingStrategy: processor.OneFieldPerSlotStrategy}
+
+	jsonP := New(processor.WithValidator(validator), processor.WithParser(parser), processor.WithSchemaLoader(loader))
+	schema, ext, err := jsonP.Load(url)
+
+	assert.Nil(t, err)
+	assert.Equal(t, ext, "json")
+	assert.NotEmpty(t, schema)
+
+	_, err = jsonP.GetFieldSlotIndex("documentType", schema)
+	assert.NotNil(t, err)
+
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -29,6 +29,7 @@ type ParsedSlots struct {
 // Parser is an interface to parse claim slots
 type Parser interface {
 	ParseSlots(data, schema []byte) (ParsedSlots, error)
+	GetFieldSlotIndex(field string, schema []byte) (int, error)
 }
 
 var (
@@ -85,6 +86,14 @@ func (s *Processor) ParseSlots(data, schema []byte) (ParsedSlots, error) {
 		return ParsedSlots{}, errParserNotDefined
 	}
 	return s.Parser.ParseSlots(data, schema)
+}
+
+// GetFieldSlotIndex returns index of slot for specified field according to schema
+func (s *Processor) GetFieldSlotIndex(field string, schema []byte) (int, error) {
+	if s.Parser == nil {
+		return 0, errParserNotDefined
+	}
+	return s.Parser.GetFieldSlotIndex(field, schema)
 }
 
 // ValidateData will validate a claim content by given schema.

--- a/utils/claims.go
+++ b/utils/claims.go
@@ -130,3 +130,13 @@ func swapEndianness(buf []byte) []byte {
 	}
 	return newBuf
 }
+
+// IndexOf returns field index in array of fields
+func IndexOf(field string, fields []string) int {
+	for k, v := range fields {
+		if field == v {
+			return k
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
new method for both parsers : GetFieldSlotIndex
now we can retrieve slot index (0-7) from the schema for a specific field